### PR TITLE
Prevent NoneType crash

### DIFF
--- a/Backdrop.glyphsReporter/Contents/Resources/plugin.py
+++ b/Backdrop.glyphsReporter/Contents/Resources/plugin.py
@@ -220,6 +220,9 @@ class backdrop(ReporterPlugin):
 	
 	@objc.python_method
 	def updateWindowUI(self):
+		if not self.currentGlyph:
+			return
+		
 		n = self.currentGlyph.parent.name
 
 		try:


### PR DESCRIPTION
Prevent this crash:

```python
Traceback (most recent call last):

 File "GlyphsApp/GlyphsApp/__init__.py", line 1273, in callback_

 File "plugin.py", line 27, in docActivated_
   self.updateWindowUI()

 File "plugin.py", line 223, in updateWindowUI
   n = self.currentGlyph.parent.name

AttributeError: 'NoneType' object has no attribute 'parent'
```